### PR TITLE
Fixed code-server not mounting codebase

### DIFF
--- a/build/docker-compose/docker-compose.code-server.yml
+++ b/build/docker-compose/docker-compose.code-server.yml
@@ -44,11 +44,7 @@ services:
       - CODE_SERVER_PASSWORD
     volumes:
       # Mount and serve contents of Drupal site.
-      - type: volume
-        source: drupal-root
-        target: /var/www/drupal
-        volume:
-          nocopy: true
+      - ../../codebase:/var/www/drupal:delegated
       # Mount and serve Drupal files.
       - type: volume
         source: drupal-sites-data
@@ -79,7 +75,7 @@ services:
       - traefik.enable=false
     volumes:
       # Allow code-server to serve Drupal / override it.
-      - drupal-root:/var/www/drupal
+      - ../../codebase:/var/www/drupal:delegated
     deploy:
       resources:
           limits:

--- a/build/docker-compose/docker-compose.code-server.yml
+++ b/build/docker-compose/docker-compose.code-server.yml
@@ -83,6 +83,5 @@ services:
           reservations:
             memory: 2G
 volumes:
-  drupal-root: {}
   drupal-sites-data: {}
   code-server-data: {}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,3 +139,13 @@ A log of the error is needed for the fix to review. A full description of the is
 To fix this:
 
 * Run `make fix_views`
+
+## For Windows, error when executing make on trying to composer install within drupal container
+**Error:**
+```bash
+docker-compose exec -T drupal with-contenv bash -lc 'composer install'
+s6-envdir: fatal: unable to envdir: No such file or directory
+```
+To fix this:
+ * edit the Makefile and replace the `docker-compose exec -T drupal with-contenv bash -lc 'composer install'` line with `docker-compose exec -T drupal composer install`
+ * rerun make


### PR DESCRIPTION
# Error Fixed
- Enabling code server service causes Drupal container to be recreated and unlinked from the codebase folder
# Change
- Modified `docker-compose.code-server.yml` such that drupal container is set to mount the codebase folder on recreate